### PR TITLE
Make Parser and Tokenizer classes public

### DIFF
--- a/src/html5/parser.cr
+++ b/src/html5/parser.cr
@@ -10,7 +10,7 @@ module HTML5
     "svg"  => [Atom::Desc, Atom::ForeignObject, Atom::Title],
   }
 
-  private enum Scope
+  enum Scope
     Default
     ListItem
     Button
@@ -22,7 +22,7 @@ module HTML5
 
   # A parser implements the HTML5 parsing algorithm:
   # https://html.spec.whatwg.org/multipage/syntax.html#tree-construction
-  private class Parser
+  class Parser
     # tokenizer provides the tokens for the parser
     protected property tokenizer : Tokenizer
     # token is the most recently used Token

--- a/src/html5/token.cr
+++ b/src/html5/token.cr
@@ -93,7 +93,7 @@ module HTML5
   end
 
   # Tokenizer returns a stream of HTML Tokens
-  private class Tokenizer
+  class Tokenizer
     # r is teh source of HTML of text
     @r : IO
     # tt is TokenType of the current token


### PR DESCRIPTION
If this isn't wanted I understand, I can always just use my fork, but I think that having the Parser and Tokenizer available for use outside of the library could be very useful to some (like me).